### PR TITLE
Change digest algorithm from not supported SHA

### DIFF
--- a/lib/angelo/server.rb
+++ b/lib/angelo/server.rb
@@ -114,7 +114,7 @@ module Angelo
 
     def etag_for local_path
       fs = File::Stat.new local_path
-      OpenSSL::Digest::SHA.hexdigest fs.ino.to_s + fs.size.to_s + fs.mtime.to_s
+      OpenSSL::Digest::SHA1.hexdigest fs.ino.to_s + fs.size.to_s + fs.mtime.to_s
     end
 
     def sse_event *a; Base.sse_event *a; end


### PR DESCRIPTION
Looking a the code of the openssl gem it seems that SHA is not supported 
https://github.com/ruby/openssl/blob/master/lib/openssl/digest.rb
>     alg = %w(MD2 MD4 MD5 MDC2 RIPEMD160 SHA1 SHA224 SHA256 SHA384 SHA512)
when i tried Angelo locally on mac i receive this error 
NameError: uninitialized constant OpenSSL::Digest::SHA